### PR TITLE
Switch to @conda-forge/spacy team

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,9 +405,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@adrianeboyd](https://github.com/adrianeboyd/)
 * [@h-vetinari](https://github.com/h-vetinari/)
-* [@honnibal](https://github.com/honnibal/)
-* [@ines](https://github.com/ines/)
 * [@rmax](https://github.com/rmax/)
+* [@conda-forge/spacy](https://github.com/orgs/conda-forge/teams/spacy/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,6 +52,4 @@ extra:
   recipe-maintainers:
     - rmax
     - h-vetinari
-    - ines
-    - honnibal
-    - adrianeboyd
+    - conda-forge/spacy


### PR DESCRIPTION
I saw this team being used on a new feedstock and I am trying to see if I can make this change without running any builds.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
